### PR TITLE
Fixed issues with compiling under Swift 2.3

### DIFF
--- a/UIImageColors.podspec
+++ b/UIImageColors.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = "UIImageColors"
-  spec.version     = "1.0.6"
+  spec.version     = "1.0.5"
   spec.license     = "MIT"
   spec.summary     = "iTunes style color fetcher for UIImage."
   spec.homepage    = "https://github.com/jathu/UIImageColors"

--- a/UIImageColors.podspec
+++ b/UIImageColors.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = "UIImageColors"
-  spec.version     = "1.0.5"
+  spec.version     = "1.0.6"
   spec.license     = "MIT"
   spec.summary     = "iTunes style color fetcher for UIImage."
   spec.homepage    = "https://github.com/jathu/UIImageColors"


### PR DESCRIPTION
UIImage.CGImage and UIGraphicsGetImageFromCurrentImageContext() are now optional in Swift 2.3, so this change fixes this issue in a way that is compatible with Swift 2.2 as well.
