### PR TITLE
Force unwrap CGImage for Swift 2.3 compatibility

### DIFF
--- a/UIImageColors.swift
+++ b/UIImageColors.swift
@@ -134,7 +134,7 @@ extension UIImage {
         
         var result = UIImageColors()
         
-        let cgImage = self.resizeForUIImageColors(scaleDownSize).CGImage
+        let cgImage = self.resizeForUIImageColors(scaleDownSize).CGImage!
         let width = CGImageGetWidth(cgImage)
         let height = CGImageGetHeight(cgImage)
         

--- a/UIImageColorsPlayground.playground/Sources/UIImageColors.swift
+++ b/UIImageColorsPlayground.playground/Sources/UIImageColors.swift
@@ -134,7 +134,7 @@ extension UIImage {
         
         var result = UIImageColors()
         
-        let cgImage = self.resizeForUIImageColors(scaleDownSize).CGImage
+        let cgImage = self.resizeForUIImageColors(scaleDownSize).CGImage!
         let width = CGImageGetWidth(cgImage)
         let height = CGImageGetHeight(cgImage)
         


### PR DESCRIPTION
Looks like there was one more optional-related issue preventing the file from compiling under Swift 2.3. Sorry for the spam!
