### PR TITLE
Use pod_target_xcconfig to configure Swift version

### DIFF
--- a/UIImageColors.podspec
+++ b/UIImageColors.podspec
@@ -10,4 +10,7 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = "8.0"
   spec.source_files = "Sources/*.swift"
   spec.requires_arc = true
+  s.pod_target_xcconfig = {
+    'SWIFT_VERSION' => '3.0'
+  }
 end


### PR DESCRIPTION
- Same PR with https://github.com/devxoul/Toaster/pull/92
- Without this specified, uses should use the script above in their Podfile.
  
  ``` ruby
  post_install do |installer|
    installer.pods_project.targets.each do |target|
      target.build_configurations.each do |config|
        config.build_settings['SWIFT_VERSION'] = '3.0'
      end
    end
  end
  ```
