### PR TITLE
UIImageColors struct now has public member-wise initializer.

### DIFF
--- a/Sources/UIImageColors.swift
+++ b/Sources/UIImageColors.swift
@@ -12,6 +12,13 @@ public struct UIImageColors {
     public var primary: UIColor!
     public var secondary: UIColor!
     public var detail: UIColor!
+  
+    public init(background: UIColor, primary: UIColor, secondary: UIColor, detail: UIColor) {
+      self.background = background
+      self.primary = primary
+      self.secondary = secondary
+      self.detail = detail
+    }
 }
 
 public enum UIImageColorsQuality: CGFloat {


### PR DESCRIPTION
By default, the member-wise initializer for public structs is **private**.  If we include an explicit public init, then we can create UIImageColor structs in other modules.

For example, here is an extension to make the UIImageColors struct cacheable with Haneke: https://gist.github.com/raphaeltraviss/fa620780eacc8d57f2d75424b1b796b8