### PR TITLE
Update Package.swift for Xcode 11 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/xcuserdata
 *.pbxuser
 *.mode1v3
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,13 @@
+// swift-tools-version:5.0
+
 import PackageDescription
 
 let package = Package(
-  name: "UIImageColors"
+    name: "UIImageColors",
+    products: [
+        .library(name: "UIImageColors", targets: ["UIImageColors"])
+    ],
+    targets: [
+        .target(name: "UIImageColors", path: "UIImageColors")
+    ]
 )


### PR DESCRIPTION
The motivation for this change was to be able to integrate your library with a project I'm working on using Xcode 11's SPM functionality. It doesn't work with the current Package.swift, so I've added a target and library product that allows it to work for both iOS and macOS projects.

I also added .swiftpm to the .gitignore, which is generated by Xcode when you open a Package.swift file with it but only contains user-specific data.