### PR TITLE
Use `cgImage.bytesPerRow` instead of `width`

### DIFF
--- a/UIImageColors.podspec
+++ b/UIImageColors.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = "UIImageColors"
-  spec.version     = "2.2.0"
+  spec.version     = "2.3.0"
   spec.license     = "MIT"
   spec.summary     = "iTunes style color fetcher for UIImage and NSImage."
   spec.homepage    = "https://github.com/jathu/UIImageColors"

--- a/UIImageColors/Sources/UIImageColors.swift
+++ b/UIImageColors/Sources/UIImageColors.swift
@@ -247,7 +247,7 @@ extension UIImage {
         let imageColors = NSCountedSet(capacity: width*height)
         for x in 0..<width {
             for y in 0..<height {
-                let pixel: Int = ((width * y) + x) * 4
+                let pixel: Int = y * cgImage.bytesPerRow + x * 4
                 if 127 <= data[pixel+3] {
                     imageColors.add((Double(data[pixel+2])*1000000)+(Double(data[pixel+1])*1000)+(Double(data[pixel])))
                 }

--- a/UIImageColors/Sources/UIImageColors.swift
+++ b/UIImageColors/Sources/UIImageColors.swift
@@ -247,7 +247,7 @@ extension UIImage {
         let imageColors = NSCountedSet(capacity: width*height)
         for x in 0..<width {
             for y in 0..<height {
-                let pixel: Int = y * cgImage.bytesPerRow + x * 4
+                let pixel: Int = (y * cgImage.bytesPerRow) + (x * 4)
                 if 127 <= data[pixel+3] {
                     imageColors.add((Double(data[pixel+2])*1000000)+(Double(data[pixel+1])*1000)+(Double(data[pixel])))
                 }

--- a/UIImageColors/Supporting Files/Info.plist
+++ b/UIImageColors/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Because the bitmap data allocated may be padded.